### PR TITLE
Added New Route to get all the videos and videos by status

### DIFF
--- a/app/controllers/video_controller.py
+++ b/app/controllers/video_controller.py
@@ -33,6 +33,38 @@ def upload_video_controller(request):
 
     return jsonify({'message': 'File uploaded successfully', 'video_id': video.id, 'id': result.id}), 201
 
+
+def get_all_videos_controller(status=None, page=1, per_page=10):
+    query = Video.query
+    
+    if status:
+        query = query.filter_by(status=status)
+    
+    pagination = query.paginate(page=page, per_page=per_page, error_out=False)
+    
+    videos = pagination.items
+    total_videos = pagination.total
+    total_pages = pagination.pages
+    current_page = pagination.page
+    
+    videos_data = [{
+        'video_id': video.id,
+        'filename': video.filename,
+        'status': video.status,
+        'created_at': video.created_at.isoformat(),
+        'updated_at': video.updated_at.isoformat()
+    } for video in videos]
+    
+    return jsonify({
+        'videos': videos_data,
+        'total_videos': total_videos,
+        'total_pages': total_pages,
+        'current_page': current_page,
+        'per_page': per_page
+    }), 200
+
+
+
 def abort_video_processing_controller(task_id): 
     task = process_video_task.AsyncResult(task_id)
     task.abort()

--- a/app/routes/video_routes.py
+++ b/app/routes/video_routes.py
@@ -1,7 +1,7 @@
 # app/routes/video_routes.py
 
 from flask import Blueprint, request, jsonify, current_app, render_template
-from app.controllers.video_controller import upload_video_controller, get_video_status_controller, abort_video_processing_controller
+from app.controllers.video_controller import upload_video_controller, get_video_status_controller, abort_video_processing_controller, get_all_videos_controller
 from app.models.video import Video
 
 video_blueprint = Blueprint('video', __name__)
@@ -20,10 +20,21 @@ def upload_video_route():
 def get_video_status_route(task_id):
     return get_video_status_controller(task_id)
   
+
 @video_blueprint.route('/api/video/abort/<string:task_id>', methods=['POST'])
 def abort_video_processing_route(task_id):
     return abort_video_processing_controller(task_id)
+
+
+@video_blueprint.route('/api/videos', methods=['GET'])
+def get_all_videos_route():
+    status = request.args.get('status')
+    page = request.args.get('page', 1, type=int)
+    per_page = request.args.get('per_page', 10, type=int)
     
+    return get_all_videos_controller(status, page, per_page)
+
+
 @video_blueprint.app_errorhandler(404)
 def page_not_found(e):
     return render_template('pages/404.html'), 404

--- a/app/tasks/video_tasks.py
+++ b/app/tasks/video_tasks.py
@@ -16,17 +16,13 @@ def process_video_task(self, video_id, file_path):
             logging.error(f'Video with id {video_id} not found')
             return
         
-        # Update status to queued
-        video.status = Video.STATUS_QUEUED
-        db.session.commit()
-
         # Simulate processing delay
         time.sleep(5)  # Simulate a delay before processing
         
-        if self.is_aborted:
-            print(f'Processing aborted for video_id: {video_id}')
-            logging.info(f'Processing aborted for video_id: {video_id}')
-            return
+        # if self.is_aborted:
+        #     print(f'Processing aborted for video_id: {video_id}')
+        #     logging.info(f'Processing aborted for video_id: {video_id}')
+        #     return
 
         # Update status to processing
         video.status = Video.STATUS_PROCESSING


### PR DESCRIPTION
added ` /api/videos ` route to get the all the videos tasks. And this response data will be in paginated json
sample response 
```json
{
    "current_page": 1,
    "per_page": 10,
    "total_pages": 1,
    "total_videos": 2,
    "videos": [
        {
            "created_at": "2024-09-06T07:13:22.227290",
            "filename": "Do_This_Every_Time_You_Get_Paid._Accountant_Payday_Routine.mp4",
            "status": "queued",
            "updated_at": "2024-09-06T07:13:22.227293",
            "video_id": 1
        },
        {
            "created_at": "2024-09-06T07:17:18.628666",
            "filename": "Do_This_Every_Time_You_Get_Paid._Accountant_Payday_Routine.mp4",
            "status": "completed",
            "updated_at": "2024-09-06T07:17:33.688202",
            "video_id": 2
        }
    ]
}
```
can also pass status as query params to it to filter the data 
like ` /api/videos?stauts=completed`
different status are 
1. completed
2. queued
3. processing
4. failed
5. pending
